### PR TITLE
feat: 상품 주문하기 버튼 구현

### DIFF
--- a/src/components/cart/AddCartButton.tsx
+++ b/src/components/cart/AddCartButton.tsx
@@ -27,6 +27,7 @@ export const AddCartButton = (item: CartItem) => {
       alert('동일한 상품이 장바구니에 있어 수량이 변경됩니다.');
       updateItem(item);
     } else {
+      alert('상품이 장바구니에 추가되었습니다.');
       addItem(item);
     }
   };

--- a/src/components/cart/CartTotal.tsx
+++ b/src/components/cart/CartTotal.tsx
@@ -1,10 +1,10 @@
 'use client';
 
 import { Item } from '@/types/cartType';
-import { Button } from '../ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '../ui/card';
 import { formatNumber } from '@/utils/formatNumber';
 import { cartStore } from '@/store/cartStore';
+import { OrderButton } from './OrderButton';
 
 type CartTotalProps = {
   items: Item[];
@@ -17,6 +17,7 @@ type CartTotalProps = {
 export const CartTotal = ({ items }: CartTotalProps) => {
   const storeItems = cartStore((state) => state.items);
 
+  // 총 수량 및 금액 계산
   const total = items.reduce(
     (result, item) => {
       result.amount += storeItems[item.item_id];
@@ -25,6 +26,9 @@ export const CartTotal = ({ items }: CartTotalProps) => {
     },
     { amount: 0, price: 0 },
   );
+
+  // 선택된 아이템들의 id 배열 생성 (주문하기 버튼에 전달용)
+  const selectedItemIds = items.map((item) => item.item_id);
 
   return (
     <Card className="my-5 w-[300px] self-end">
@@ -40,7 +44,7 @@ export const CartTotal = ({ items }: CartTotalProps) => {
           <span className="text-gray-600">총 금액</span>
           <span className="font-bold">{formatNumber(total.price)}원</span>
         </div>
-        <Button className="mt-3 font-bold">주문하기</Button>
+        <OrderButton itemIds={selectedItemIds} />
       </CardContent>
     </Card>
   );

--- a/src/components/cart/OrderButton.tsx
+++ b/src/components/cart/OrderButton.tsx
@@ -1,0 +1,67 @@
+import { cartStore } from '@/store/cartStore';
+import { Button } from '../ui/button';
+import useAuthStore from '@/store/authStore';
+import { useRouter } from 'next/navigation';
+import supabase from '@/services/supabase';
+
+type OrderButtonProps = {
+  itemIds: number[];
+};
+
+/**
+ * 주문하기 버튼 컴포넌트
+ * @param OrderButtonProps.itemIds - 주문할 상품의 id 배열
+ */
+export const OrderButton = ({ itemIds }: OrderButtonProps) => {
+  const storeItems = cartStore((state) => state.items);
+  const removeItem = cartStore((state) => state.removeItem);
+  const user = useAuthStore((state) => state.user);
+  const router = useRouter();
+
+  /** 주문하기 버튼 클릭 리스너 */
+  const handleClickOrder = async () => {
+    if (!user) {
+      alert('로그인이 필요합니다.');
+      router.push('/login');
+    }
+    const isConfirmed = confirm('주문하시겠습니까?');
+    if (!isConfirmed) return;
+
+    try {
+      // 유저의 uuid 가져오기
+      const {
+        data: { user },
+        error,
+      } = await supabase.auth.getUser();
+      const userId = user?.id;
+
+      if (error) throw new Error(error.message);
+
+      // 아이템 순회하면서 DB에 저장
+      itemIds.forEach(async (item) => {
+        const orderData = {
+          item_id: item,
+          buyer_id: userId,
+          amount: storeItems[item],
+          created_at: new Date(),
+          order_status: 'pending',
+        };
+
+        const { error } = await supabase.from('ordered_items').insert(orderData);
+        if (error) throw new Error(error.message);
+
+        // 주문한 아이템 삭제
+        alert('주문이 완료되었습니다.');
+        removeItem(itemIds.map((id) => id.toString()));
+      });
+    } catch (error) {
+      console.error(error);
+    }
+  };
+
+  return (
+    <Button onClick={handleClickOrder} className="mt-3 font-bold">
+      주문하기
+    </Button>
+  );
+};

--- a/src/store/authStore.ts
+++ b/src/store/authStore.ts
@@ -1,5 +1,4 @@
 import { create } from 'zustand';
-import { persist } from 'zustand/middleware';
 
 type AuthState = {
   user: { email: string; nickname: string } | null;
@@ -13,29 +12,22 @@ type AuthState = {
   logout: () => void;
 };
 
-const useAuthStore = create<AuthState>()(
-  persist(
-    (set) => ({
+const useAuthStore = create<AuthState>()((set) => ({
+  user: null,
+  accessToken: null,
+  refreshToken: null,
+  login: (user, accessToken, refreshToken) =>
+    set({
+      user,
+      accessToken,
+      refreshToken,
+    }),
+  logout: () =>
+    set({
       user: null,
       accessToken: null,
       refreshToken: null,
-      login: (user, accessToken, refreshToken) =>
-        set({
-          user,
-          accessToken,
-          refreshToken,
-        }),
-      logout: () =>
-        set({
-          user: null,
-          accessToken: null,
-          refreshToken: null,
-        }),
     }),
-    {
-      name: 'auth-storage',
-    },
-  ),
-);
+}));
 
 export default useAuthStore;

--- a/src/types/cartType.ts
+++ b/src/types/cartType.ts
@@ -10,7 +10,6 @@ export type Item = {
   stock: number;
   price: number;
   img_list?: string; // JSON 문자열
-  item_id: number;
 };
 
 /**


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- #6 

<br>

## 📝 작업 내용

- 주문하기 버튼 및 로직을 구현했습니다.
- 장바구니 추가 버튼에 alert를 추가했습니다.
- `authStore`에 `persist`를 뺐습니다.
- 선제님이 알려주신 방법으로 리팩토링하려고 했는데 리액트 쿼리 추가하고 복잡해져서 처참히 실패했습니다 ㅠ

<br>

## 🖼️ 스크린샷

<img width="1182" alt="image" src="https://github.com/user-attachments/assets/f41beb42-6d9e-4e3b-9cb0-55e61d3983ad" />

<br><br>

## 💬 리뷰 요구사항

1. 🚨 `ordered_items` 테이블의 `stock` 컬럼 이름을 `amount`로 변경했습니다! 참고 바랍니다 🚨
2. 지금 유저의 uuid 가져오기 및 주문 내역 저장 로직을 버튼 내부에 두었는데 짧더라도 api 파일에 분리할까요?

<br>